### PR TITLE
Set thread as daemon to kill it when program exits

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,6 +145,7 @@ if __name__ == "__main__":
     logs.write("Debug value is {0}".format(debugval), 'working')
     logs.write("Connecting to rtm socket", 'trying')
     t = threading.Thread(target=slack)
+    t.daemon=True #Kills the thread on program exit
     t.start()
     logs.write("Starting flask server on localhost", 'trying')
     print app.run(debug=debugval, use_reloader=False)


### PR DESCRIPTION
Setting the thread to invoke the slack client as a daemon would cause it exit when the user issues Ctrl+C to quit the program. Else, the user has to close the terminal to kill the program.
