### PR TITLE
Add "env" directory for virtualenv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ content.txt
 
 # Python specific files
 *.pyc
+env/*
 
 # IDEA
 .idea/*


### PR DESCRIPTION
Added the "env" directory for virtualenv to .gitignore.  We don't need the python virtual environment and installed dependencies showing up when to work with the git repo.
